### PR TITLE
Add harpSpatial note to README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -75,5 +75,19 @@ In this case you only have to set them once and not worry about it when you wish
 
 When setting environment variables or creating a Makevars file, R must be restarted for the changes to take effect before running `remotes::install_github("andrew_MET/harp")`.
 
+### A note about harpSpatial
+harpSpatial imports a package (SpatialVx) that depends on a package that depends on another package (conquer) that requires an R version of 3.6 or newer. If you don't need to use harpSpatial you can install the other harp packages individually, and when you're working you will also need to attach them individually:
+```{r eval=FALSE}
+remotes::install_github("harphub/harpIO")
+remotes::install_github("harphub/harpPoint")
+remotes::install_github("harphub/harpVis")
+
+library(harpIO)
+library(harpPoint)
+library(harpVis)
+```
+
+We are working on removing the dependency on SpatialVx, so hopefully this wont be an issue soon. 
+
 ## Workflows
 The purpose of this website is to demonstrate common workflows, such as point and spatial verification, score card generation, and data analysis using the __harp__ packages. 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,27 @@ When setting environment variables or creating a Makevars file, R must
 be restarted for the changes to take effect before running
 `remotes::install_github("andrew_MET/harp")`.
 
+### A note about harpSpatial
+
+harpSpatial imports a package (SpatialVx) that depends on a package that
+depends on another package (conquer) that requires an R version of 3.6
+or newer. If you don’t need to use harpSpatial you can install the other
+harp packages individually, and when you’re working you will also need
+to attach them individually:
+
+``` r
+remotes::install_github("harphub/harpIO")
+remotes::install_github("harphub/harpPoint")
+remotes::install_github("harphub/harpVis")
+
+library(harpIO)
+library(harpPoint)
+library(harpVis)
+```
+
+We are working on removing the dependency on SpatialVx, so hopefully
+this wont be an issue soon.
+
 ## Workflows
 
 The purpose of this website is to demonstrate common workflows, such as

--- a/docs/index.html
+++ b/docs/index.html
@@ -119,6 +119,19 @@
 <p>In this case you only have to set them once and not worry about it when you wish to install an update to meteogrid.</p>
 <p>When setting environment variables or creating a Makevars file, R must be restarted for the changes to take effect before running <code><a href="https://remotes.r-lib.org/reference/install_github.html">remotes::install_github("andrew_MET/harp")</a></code>.</p>
 </div>
+<div id="a-note-about-harpspatial" class="section level3">
+<h3 class="hasAnchor">
+<a href="#a-note-about-harpspatial" class="anchor"></a>A note about harpSpatial</h3>
+<p>harpSpatial imports a package (SpatialVx) that depends on a package that depends on another package (conquer) that requires an R version of 3.6 or newer. If you don’t need to use harpSpatial you can install the other harp packages individually, and when you’re working you will also need to attach them individually:</p>
+<div class="sourceCode" id="cb7"><pre class="r"><span class="kw pkg">remotes</span><span class="kw ns">::</span><span class="fu"><a href="https://remotes.r-lib.org/reference/install_github.html">install_github</a></span>(<span class="st">"harphub/harpIO"</span>)
+<span class="kw pkg">remotes</span><span class="kw ns">::</span><span class="fu"><a href="https://remotes.r-lib.org/reference/install_github.html">install_github</a></span>(<span class="st">"harphub/harpPoint"</span>)
+<span class="kw pkg">remotes</span><span class="kw ns">::</span><span class="fu"><a href="https://remotes.r-lib.org/reference/install_github.html">install_github</a></span>(<span class="st">"harphub/harpVis"</span>)
+
+<span class="fu"><a href="https://rdrr.io/r/base/library.html">library</a></span>(<span class="no">harpIO</span>)
+<span class="fu"><a href="https://rdrr.io/r/base/library.html">library</a></span>(<span class="no">harpPoint</span>)
+<span class="fu"><a href="https://rdrr.io/r/base/library.html">library</a></span>(<span class="no">harpVis</span>)</pre></div>
+<p>We are working on removing the dependency on SpatialVx, so hopefully this wont be an issue soon.</p>
+</div>
 </div>
 <div id="workflows" class="section level2">
 <h2 class="hasAnchor">


### PR DESCRIPTION
SpatialVx, which is imported by harpSaptial has a dependency on the conquer package somewhere in its dependency tree (it's not a direct dependency). The conquer package requires R >= 3.6 so a note is added to the README to inform the user. 