### PR TITLE
Move harpSpatial to Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: harp
 Title: harp
-Version: 0.0.0.9028
+Version: 0.0.0.9029
 Authors@R: as.person(c(
     "Andrew Singleton <andrewts@met.no> [aut, cre]", 
     "Alex Deckmyn <alex.deckmyn@meteo.be> [aut]"
@@ -12,8 +12,7 @@ LazyData: true
 Depends: 
     harpIO,
     harpPoint,
-    harpVis,
-    harpSpatial
+    harpVis
 Remotes: 
     harphub/harpIO,
     harphub/harpPoint,
@@ -23,5 +22,6 @@ URL: https://github.com/harphub/harp
 BugReports: https://github.com/harphub/harp/issues
 Suggests: 
     knitr,
-    rmarkdown
+    rmarkdown,
+    harpSpatial
 VignetteBuilder: knitr

--- a/README.Rmd
+++ b/README.Rmd
@@ -76,15 +76,12 @@ In this case you only have to set them once and not worry about it when you wish
 When setting environment variables or creating a Makevars file, R must be restarted for the changes to take effect before running `remotes::install_github("andrew_MET/harp")`.
 
 ### A note about harpSpatial
-harpSpatial imports a package (SpatialVx) that depends on a package that depends on another package (conquer) that requires an R version of 3.6 or newer. If you don't need to use harpSpatial you can install the other harp packages individually, and when you're working you will also need to attach them individually:
+harpSpatial imports the package [SpatialVx](https://cran.r-project.org/package=SpatialVx) that has a dependency tree that depends on the package [conquer](https://cran.r-project.org/package=conquer), which requires R version >= 3.6. For this reason harpSpatial is not part of the harp meta-package and currently needs to be installed and attached separately:  
 ```{r eval=FALSE}
-remotes::install_github("harphub/harpIO")
-remotes::install_github("harphub/harpPoint")
-remotes::install_github("harphub/harpVis")
+remotes::install_github("harphub/harpSpatial")
 
-library(harpIO)
-library(harpPoint)
-library(harpVis)
+library(harp)
+library(harpSpatial)
 ```
 
 We are working on removing the dependency on SpatialVx, so hopefully this wont be an issue soon. 

--- a/README.md
+++ b/README.md
@@ -89,20 +89,19 @@ be restarted for the changes to take effect before running
 
 ### A note about harpSpatial
 
-harpSpatial imports a package (SpatialVx) that depends on a package that
-depends on another package (conquer) that requires an R version of 3.6
-or newer. If you don’t need to use harpSpatial you can install the other
-harp packages individually, and when you’re working you will also need
-to attach them individually:
+harpSpatial imports the package
+[SpatialVx](https://cran.r-project.org/package=SpatialVx) that has a
+dependency tree that depends on the package
+[conquer](https://cran.r-project.org/package=conquer), which requires R
+version \>= 3.6. For this reason harpSpatial is not part of the harp
+meta-package and currently needs to be installed and attached
+separately:
 
 ``` r
-remotes::install_github("harphub/harpIO")
-remotes::install_github("harphub/harpPoint")
-remotes::install_github("harphub/harpVis")
+remotes::install_github("harphub/harpSpatial")
 
-library(harpIO)
-library(harpPoint)
-library(harpVis)
+library(harp)
+library(harpSpatial)
 ```
 
 We are working on removing the dependency on SpatialVx, so hopefully

--- a/docs/index.html
+++ b/docs/index.html
@@ -122,14 +122,11 @@
 <div id="a-note-about-harpspatial" class="section level3">
 <h3 class="hasAnchor">
 <a href="#a-note-about-harpspatial" class="anchor"></a>A note about harpSpatial</h3>
-<p>harpSpatial imports a package (SpatialVx) that depends on a package that depends on another package (conquer) that requires an R version of 3.6 or newer. If you don’t need to use harpSpatial you can install the other harp packages individually, and when you’re working you will also need to attach them individually:</p>
-<div class="sourceCode" id="cb7"><pre class="r"><span class="kw pkg">remotes</span><span class="kw ns">::</span><span class="fu"><a href="https://remotes.r-lib.org/reference/install_github.html">install_github</a></span>(<span class="st">"harphub/harpIO"</span>)
-<span class="kw pkg">remotes</span><span class="kw ns">::</span><span class="fu"><a href="https://remotes.r-lib.org/reference/install_github.html">install_github</a></span>(<span class="st">"harphub/harpPoint"</span>)
-<span class="kw pkg">remotes</span><span class="kw ns">::</span><span class="fu"><a href="https://remotes.r-lib.org/reference/install_github.html">install_github</a></span>(<span class="st">"harphub/harpVis"</span>)
+<p>harpSpatial imports the package <a href="https://cran.r-project.org/package=SpatialVx">SpatialVx</a> that has a dependency tree that depends on the package <a href="https://cran.r-project.org/package=conquer">conquer</a>, which requires R version &gt;= 3.6. For this reason harpSpatial is not part of the harp meta-package and currently needs to be installed and attached separately:</p>
+<div class="sourceCode" id="cb7"><pre class="r"><span class="kw pkg">remotes</span><span class="kw ns">::</span><span class="fu"><a href="https://remotes.r-lib.org/reference/install_github.html">install_github</a></span>(<span class="st">"harphub/harpSpatial"</span>)
 
-<span class="fu"><a href="https://rdrr.io/r/base/library.html">library</a></span>(<span class="no">harpIO</span>)
-<span class="fu"><a href="https://rdrr.io/r/base/library.html">library</a></span>(<span class="no">harpPoint</span>)
-<span class="fu"><a href="https://rdrr.io/r/base/library.html">library</a></span>(<span class="no">harpVis</span>)</pre></div>
+<span class="fu"><a href="https://rdrr.io/r/base/library.html">library</a></span>(<span class="no">harp</span>)
+<span class="fu"><a href="https://rdrr.io/r/base/library.html">library</a></span>(<span class="no">harpSpatial</span>)</pre></div>
 <p>We are working on removing the dependency on SpatialVx, so hopefully this wont be an issue soon.</p>
 </div>
 </div>


### PR DESCRIPTION
Since harpSpatial has a dependency that requires R >= 3.6, harpSpatial is moved to "Suggests" until that dependency is removed.